### PR TITLE
【MOD】在MAC电脑上使用SWITCH HOST软件配置域名时，空格用的是\u00A0，是否需要适配一下？

### DIFF
--- a/src/main/java/io/leopard/javahost/impl/AbstractHosts.java
+++ b/src/main/java/io/leopard/javahost/impl/AbstractHosts.java
@@ -59,7 +59,7 @@ public abstract class AbstractHosts implements Hosts {
 			return list;
 		}
 
-		String[] hosts = line.split("\\s+");
+		String[] hosts = line.split("\\s+|\\u00A0+");
 		if (hosts.length < 2) {
 			throw new RuntimeException("非法host记录[" + line + "].");
 		}


### PR DESCRIPTION
在MAC电脑上使用SWITCH HOST软件配置域名时，空格用的是\u00A0，用原来的正则表达式检查不出来，后续会报错，是否要改一下正则表达式？